### PR TITLE
Ignite

### DIFF
--- a/bin/icp
+++ b/bin/icp
@@ -34,7 +34,7 @@ icp_file_tmp=$icp_file.tmp
 
 if [ -f $icp_file ]; then
     files_to_copy=$(cat $icp_file)
-else
+elif [ -z "$destination" ]; then
     files_to_copy=$(
         git -C $source ls-files --ignored --others --exclude-standard | \
         fzf --multi \
@@ -46,6 +46,11 @@ else
                 head --lines=100 -v {}
             '
     )
+fi
+
+if [ -z "$files_to_copy" ]; then
+    echo "No .icp file found"
+    exit 0
 fi
 
 cat /dev/null > $icp_file_tmp

--- a/bin/ignite
+++ b/bin/ignite
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+ignite_file=".ignite"
+
+if [ ! -f $ignite_file ]; then
+	echo "No $ignite_file file found"
+	exit 1
+fi
+
+cat $ignite_file | sh

--- a/bin/ignite
+++ b/bin/ignite
@@ -4,7 +4,7 @@ ignite_file=".ignite"
 
 if [ ! -f $ignite_file ]; then
 	echo "No $ignite_file file found"
-	exit 1
+	exit 0
 fi
 
 cat $ignite_file | sh

--- a/bin/ignite
+++ b/bin/ignite
@@ -9,4 +9,4 @@ fi
 
 echo "Found $ignite_file, igniting..."
 
-cat $ignite_file | sh
+cat $ignite_file | $SHELL

--- a/bin/ignite
+++ b/bin/ignite
@@ -7,4 +7,6 @@ if [ ! -f $ignite_file ]; then
 	exit 0
 fi
 
+echo "Found $ignite_file, igniting..."
+
 cat $ignite_file | sh

--- a/bin/wt
+++ b/bin/wt
@@ -36,15 +36,32 @@ user_selects_worktree () {
 	fzf --preview='echo; git -C {} log --oneline'
 }
 
-get_main_branch() {
-	git_dir="$1"
-	if [ -z $git_dir ]; then
-		git_dir="./"
+get_main_branch () {
+	if [ -z "$main_branch" ]; then
+		git_dir="$1"
+		if [ -z $git_dir ]; then
+			git_dir="./"
+		fi
+
+		git -C $git_dir branch --list | \
+			grep '*' | \
+			awk '{print $NF}'
+	else
+		echo $main_branch
+	fi
+}
+
+do_icp () {
+	icp $(get_main_branch) $worktree_dir
+}
+
+do_ignite () {
+	ignite_file="$(get_main_branch)/.ignite"
+	if [ -f $ignite_file ]; then
+		cp $ignite_file $worktree_dir
 	fi
 
-	git -C $git_dir branch --list | \
-	grep '*' | \
-	awk '{print $NF}'
+	cd $worktree_dir && ignite
 }
 
 new () {
@@ -56,8 +73,8 @@ new () {
 
 	git worktree add --no-track $worktree_dir -b $worktree_name origin/$branch
 
-	icp $(get_main_branch) $worktree_dir
-	cd $worktree_dir && ignite
+	do_icp
+	do_ignite
 }
 
 add () {
@@ -70,8 +87,8 @@ add () {
 	git worktree add $worktree_dir $branch
 	git -C $worktree_dir branch -u origin/$branch
 
-	icp $(get_main_branch) $worktree_dir
-	cd $worktree_dir && ignite
+	do_icp
+	do_ignite
 }
 
 remove () {

--- a/bin/wt
+++ b/bin/wt
@@ -57,6 +57,7 @@ new () {
 	git worktree add --no-track $worktree_dir -b $worktree_name origin/$branch
 
 	icp $(get_main_branch) $worktree_dir
+	cd $worktree_dir && ignite
 }
 
 add () {
@@ -70,6 +71,7 @@ add () {
 	git -C $worktree_dir branch -u origin/$branch
 
 	icp $(get_main_branch) $worktree_dir
+	cd $worktree_dir && ignite
 }
 
 remove () {


### PR DESCRIPTION
Sample `.ignite` file:

```
$NVM_DIR/nvm.sh install && corepack enable && yarn && nvim .
```

Although this will use the proper node version inside the shell script, the terminal shell will not be using the `.nvmrc` node version after the ignite script completes.

We may have to look at adding new functionality to our dotfiles such as zsh autoload:
- https://stackoverflow.com/q/23556330
- https://stackoverflow.com/a/63661686