### PR TITLE
Wt force rm

### DIFF
--- a/bin/wt
+++ b/bin/wt
@@ -7,7 +7,7 @@ print_usage () {
 	echo 'wt clone <remote-url> [clone_dir]'
 	echo 'wt new <worktree_name> [worktree_dir]'
 	echo 'wt add [worktree_dir]'
-	echo 'wt remove [-d|--delete-branch]'
+	echo 'wt remove'
 	echo 'wt help|-h|--help'
 }
 
@@ -79,9 +79,7 @@ remove () {
 	git worktree remove $worktree
 	echo "Removed worktree:" $worktree
 
-	if [ $delete_branch ]; then
-		git branch -d $branch
-	fi
+	git branch -d $branch
 }
 
 clone () {
@@ -124,10 +122,6 @@ case $cmd in
 		add
 		;;
 	"remove" | "rm")
-		case $2 in
-			"-d" | "--delete-branch")
-				delete_branch=true
-		esac
 		remove
 		;;
 	"clone" | "c")

--- a/bin/wt
+++ b/bin/wt
@@ -7,7 +7,7 @@ print_usage () {
 	echo 'wt clone <remote-url> [clone_dir]'
 	echo 'wt new <worktree_name> [worktree_dir]'
 	echo 'wt add [worktree_dir]'
-	echo 'wt remove'
+	echo 'wt remove [-f|--force]'
 	echo 'wt help|-h|--help'
 }
 
@@ -76,10 +76,10 @@ remove () {
 	worktree=$(user_selects_worktree)
 	branch=$(git -C $worktree branch --show-current)
 
-	git worktree remove $worktree
+	git worktree remove $worktree $force
 	echo "Removed worktree:" $worktree
 
-	git branch -d $branch
+	git branch $delete_branch $branch
 }
 
 clone () {
@@ -122,6 +122,16 @@ case $cmd in
 		add
 		;;
 	"remove" | "rm")
+		case $2 in
+			"-f" | "--force")
+				force="-f"
+				delete_branch="-D"
+			;;
+		*)
+			force=""
+			delete_branch="-d"
+			;;
+		esac
 		remove
 		;;
 	"clone" | "c")


### PR DESCRIPTION
We should always `git branch -d` by default to clean things up.

If when removing worktrees and branches, that we must do so forcefully, we've added the `-f` option that can be used to infer what options to pass to `git worktree remove` and `git branch -d|-D`